### PR TITLE
Fix $TABLE output when using iiv="basic" or iiv="all"

### DIFF
--- a/R/add_default_output_tables.R
+++ b/R/add_default_output_tables.R
@@ -38,8 +38,9 @@ add_default_output_tables <- function(
   ## individual parameters, first row only
   if("parameters" %in% tables && !(default_table_names[["parameters"]] %in% existing_tables)) {
     if(verbose) cli::cli_alert_info("Adding output table for individual parameters")
-    if(is.null(iiv)) {
+    if(is.null(iiv) || (is.character(iiv) && length(iiv) == 1 && iiv %in% c("basic", "all"))) {
       ## Pharmpy bug, cannot retrieve IIV if only one parameter has IIV
+      ## Also ignore shortcut strings like "basic" or "all"
       cols <- pharmr::get_individual_parameters(model)
     } else {
       cols <- iiv

--- a/R/add_default_output_tables.R
+++ b/R/add_default_output_tables.R
@@ -4,7 +4,8 @@
 #'
 #' @param model Pharmpy model object
 #' @param iiv vector of parameters with iiv. Optional, if not specified
-#' will use pharmpy function to retrieve it.
+#' will use pharmpy function to retrieve it. Shortcut strings "basic" and "all"
+#' are also treated as NULL and will auto-detect parameters.
 #' @param tables character vector of which default tables
 #' to add, options are `fit` and `parameters`.
 #' @param full_tables For the default tables, should all input columns from be

--- a/man/add_default_output_tables.Rd
+++ b/man/add_default_output_tables.Rd
@@ -18,7 +18,8 @@ add_default_output_tables(
 \item{model}{Pharmpy model object}
 
 \item{iiv}{vector of parameters with iiv. Optional, if not specified
-will use pharmpy function to retrieve it.}
+will use pharmpy function to retrieve it. Shortcut strings "basic" and "all"
+are also treated as NULL and will auto-detect parameters.}
 
 \item{tables}{character vector of which default tables
 to add, options are \code{fit} and \code{parameters}.}


### PR DESCRIPTION
When create_model() is called with iiv="basic" or iiv="all", these
shortcut strings were being passed directly to add_default_output_tables()
and used as column names, resulting in "$TABLE ID basic" instead of the
actual parameter names like "$TABLE ID CL TVKA V".

This fix checks if iiv is a shortcut string ("basic" or "all") and treats
it the same as NULL, causing the function to auto-detect parameters using
pharmr::get_individual_parameters() instead of using the string literally.

The bug was introduced in commit 43721b0 which added the iiv parameter
to work around a pharmpy issue with single-parameter IIV detection.